### PR TITLE
Fix "Invalid controller class" error in com_hotelreservation

### DIFF
--- a/com_hotelreservation/admin/services/provider.php
+++ b/com_hotelreservation/admin/services/provider.php
@@ -16,13 +16,13 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
-use Jules\Component\HotelReservation\Administrator\Extension\HotelReservationComponent;
+use Joomla\Component\HotelReservation\Administrator\Extension\HotelReservationComponent;
 
 return new class implements ServiceProviderInterface {
     public function register(Container $container)
     {
         // Register dispatcher factory with the PHP namespace of the component (per J5 API)
-        $container->registerServiceProvider(new ComponentDispatcherFactory('Jules\\Component\\HotelReservation'));
+        $container->registerServiceProvider(new ComponentDispatcherFactory('Joomla\\Component\\HotelReservation'));
         $container->registerServiceProvider(new MVCFactoryProvider('com_hotelreservation'));
 
         $container->set(

--- a/com_hotelreservation/admin/src/Controller/DisplayController.php
+++ b/com_hotelreservation/admin/src/Controller/DisplayController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\Controller;
+namespace Joomla\Component\HotelReservation\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 

--- a/com_hotelreservation/admin/src/Controller/ReservationsController.php
+++ b/com_hotelreservation/admin/src/Controller/ReservationsController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\Controller;
+namespace Joomla\Component\HotelReservation\Administrator\Controller;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/admin/src/Extension/HotelReservationComponent.php
+++ b/com_hotelreservation/admin/src/Extension/HotelReservationComponent.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\Extension;
+namespace Joomla\Component\HotelReservation\Administrator\Extension;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/admin/src/Model/ReservationsModel.php
+++ b/com_hotelreservation/admin/src/Model/ReservationsModel.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\Model;
+namespace Joomla\Component\HotelReservation\Administrator\Model;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/admin/src/Table/ReservationTable.php
+++ b/com_hotelreservation/admin/src/Table/ReservationTable.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\Table;
+namespace Joomla\Component\HotelReservation\Administrator\Table;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/admin/src/View/Reservations/HtmlView.php
+++ b/com_hotelreservation/admin/src/View/Reservations/HtmlView.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Administrator\View\Reservations;
+namespace Joomla\Component\HotelReservation\Administrator\View\Reservations;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/com_hotelreservation.xml
+++ b/com_hotelreservation/com_hotelreservation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="5.0" method="upgrade">
     <name>com_hotelreservation</name>
-    <namespace>Jules\Component\HotelReservation</namespace>
+    <namespace>Joomla\Component\HotelReservation</namespace>
     <author>Jules</author>
     <creationDate>2025-08-14</creationDate>
     <copyright>Copyright (C) 2025. All rights reserved.</copyright>
@@ -28,7 +28,7 @@
         <folder>js</folder>
     </media>
 
-    <administration component="Jules\\Component\\HotelReservation\\Administrator\\Extension\\HotelReservationComponent">
+    <administration component="Joomla\\Component\\HotelReservation\\Administrator\\Extension\\HotelReservationComponent">
         <menu link="index.php?option=com_hotelreservation">COM_HOTELRESERVATION_MENU</menu>
         <files folder="admin">
             <folder>services</folder>

--- a/com_hotelreservation/site/src/Controller/DisplayController.php
+++ b/com_hotelreservation/site/src/Controller/DisplayController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Site\Controller;
+namespace Joomla\Component\HotelReservation\Site\Controller;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/site/src/Controller/ReservationController.php
+++ b/com_hotelreservation/site/src/Controller/ReservationController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Site\Controller;
+namespace Joomla\Component\HotelReservation\Site\Controller;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/site/src/Model/ReservationModel.php
+++ b/com_hotelreservation/site/src/Model/ReservationModel.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Site\Model;
+namespace Joomla\Component\HotelReservation\Site\Model;
 
 defined('_JEXEC') or die;
 

--- a/com_hotelreservation/site/src/View/Reservation/HtmlView.php
+++ b/com_hotelreservation/site/src/View/Reservation/HtmlView.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jules\Component\HotelReservation\Site\View\Reservation;
+namespace Joomla\Component\HotelReservation\Site\View\Reservation;
 
 defined('_JEXEC') or die;
 


### PR DESCRIPTION
The component was using a custom namespace "Jules\Component\HotelReservation" which was causing the Joomla dispatcher to fail when trying to load the controller.

This commit changes the namespace to the standard "Joomla\Component\HotelReservation" across all relevant files, including the component manifest (`com_hotelreservation.xml`) and all PHP source files. This aligns the component with Joomla's conventions and resolves the fatal error.